### PR TITLE
Revise introduction and add issuer identifier details

### DIFF
--- a/draft-birkholz-did-x509.md
+++ b/draft-birkholz-did-x509.md
@@ -54,7 +54,7 @@ Some abstract
 
 # Introduction
 
-This draft aims to define an interoperable and flexible issuer identifier format for COSE messages that transport or refer to X.509 certificates using {{RFC9360}}.
+This document aims to define an interoperable and flexible issuer identifier format for COSE messages that transport or refer to X.509 certificates using {{RFC9360}}.
 The did:x509 identifier format implements a direct, resolvable binding between a certificate chain and a compact issuer string.
 It can be used in a COSE Header CWT Claims map as defined in {{RFC9597}}.
 This issuer identifier is convenient for references and policy evaluation, for example in the context of transparency ledgers.


### PR DESCRIPTION
Draft introduction. Places less emphasis on DID than https://github.com/microsoft/did-x509/blob/main/specification.md#introduction, and more focus on the practical benefits in existing usage.