### PR TITLE
Add status warning to abstract matching RFC9783

### DIFF
--- a/draft-birkholz-did-x509.md
+++ b/draft-birkholz-did-x509.md
@@ -67,6 +67,8 @@ entity:
 
 This document defines the did:x509 decentralized identifier method, which enables a direct, resolvable binding between X.509 certificate chains and compact issuer identifiers (DID string). In particular, the did:x509 identifier format in this documents comes with a CWT Claims definition. In general, this identifier is a compact and interoperable mechanism for certificate-based identification by combining a certification path fingerprint with optional policies for subject names, subject alternative names, extended key usage, and issuer information. It is especially useful for policy evaluation and reference in transparency services and similar systems requiring cryptographic binding to certificate material.
 
+This Informational document is published as an Independent Submission to improve interoperability with Microsoft's architecture. It is not a standard nor a product of the IETF.
+
 --- middle
 
 # Introduction


### PR DESCRIPTION
Address ISE Editor comment:

> Any independent submission should include text in the abstract that reminds the reader this this independent submission is NOT a standard, and does not enjoy community consensus.

Taken from https://www.rfc-editor.org/rfc/rfc9783.html